### PR TITLE
Revert "chore(deps): bump hyper from 0.14.13 to 0.14.14"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,9 +765,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.14"
+version = "0.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
+checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
 dependencies = [
  "bytes",
  "futures-channel",


### PR DESCRIPTION
Reverts conblem/acme-dns-rust#216